### PR TITLE
Add new on-demand configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to `laravel-http-client-logger` will be documented in this file.
 
-## 1.0.0 - 202X-XX-XX
+## Upgrade guides
+
+### 0.2.0 => 0.3.0
+
+This release includes breaking changes:
+
+- `HttpLoggerInterface`: Signature changed with the addition of optional array parameter `$config`
+- `HttpLoggingFilterInterface`: Signature changed with the addition of optional array parameter `$config`
+- Macro `log()`: Signature changed with the addition of optional array parameter `$config`
+- Macro `logWhen()`: Signature changed with the addition of optional array parameter `$config`
+
+The following changes are required when updating:
+
+- If the parameter `$context['replace']` is provided to any of the methods above this must instead be provided in the newly added `$config['replace']`
+- The same change must be made if the parameter `$context['filename']` has been provided
+- Any calls to the `log` or `logWhen` macro where logger or filter is provided must add an empty array before the logger parameter due to the new method signature
+- Any custom implementation of `HttpLoggerInterface` and `HttpLoggingFilterInterface` must be refactored to fit the new method signature
+- Optional: Republish configuration file
+
+## Changes
+
+### 0.3.0
+
+- Add on-demand configuration array (breaking change)
+
+### 0.2.0
+
+- Refactor configuration (breaking change)
+- Add logging to a flysystem disk
+- Bugfix: `$context` not being passed down when using request macros
+
+### 0.1.0
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -45,12 +45,20 @@ Http::log(['note' => 'Something to log'])->get('https://example.com');
 Http::logWhen($condition, ['note' => 'Something to log'])->get('https://example.com');
 ```
 
+### Providing on-demand configuration
+It is possible to provide on-demand configuration which will override the package configuration specified in `config/laravel-http-client-logger.php`:
+```php
+Http::log($context, ['example-config-key' => 'value'])->get('https://example.com');
+// or
+Http::logWhen($condition, $context, ['example-config-key' => 'value'])->get('https://example.com');
+```
+
 ### Specifying a logger
 The default logger and filter are specified in the package configuration `logger` and `filter` respectively but can be changed at runtime using:
 ```php
-Http::log($context, $logger, $filter)->get('https://example.com');
+Http::log($context, $config, $logger, $filter)->get('https://example.com');
 // or
-Http::logWhen($condition, $context, $logger, $filter)->get('https://example.com');
+Http::logWhen($condition, $context, $config, $logger, $filter)->get('https://example.com');
 ```
 Note that the logger must implement `HttpLoggerInterface` while the filter must implement `HttpLoggingFilterInterface`.
 

--- a/config/http-client-logger.php
+++ b/config/http-client-logger.php
@@ -83,7 +83,9 @@ return [
     */
     'log_to_disk' => [
         'enabled' => env('HTTP_CLIENT_LOGGER_DISK_LOG_ENABLED', true),
-        'disk' => env('HTTP_CLIENT_LOGGER_DISK'), // uses the default filesystem disk unless specified
+        'disk' => env('HTTP_CLIENT_LOGGER_DISK'), // uses the default filesystem disk if none is specified
         'separate' => true,
+        'timestamp' => 'Y-m-d-Hisu', // Leaving empty will remove the timestamp
+        'filename' => '',
     ],
 ];

--- a/src/HttpLoggerInterface.php
+++ b/src/HttpLoggerInterface.php
@@ -11,6 +11,7 @@ interface HttpLoggerInterface
         RequestInterface $request,
         ResponseInterface $response,
         float $sec,
-        array $context = []
+        array $context = [],
+        array $config = []
     ): void;
 }

--- a/src/HttpLoggingFilter.php
+++ b/src/HttpLoggingFilter.php
@@ -11,7 +11,8 @@ class HttpLoggingFilter implements HttpLoggingFilterInterface
         RequestInterface $request,
         ResponseInterface $response,
         float $sec,
-        array $context = []
+        array $context = [],
+        array $config = []
     ): bool {
         if (! config('http-client-logger.enabled')) {
             return false;

--- a/src/HttpLoggingFilterInterface.php
+++ b/src/HttpLoggingFilterInterface.php
@@ -12,6 +12,7 @@ interface HttpLoggingFilterInterface
         RequestInterface $request,
         ResponseInterface $response,
         float $sec,
-        array $context = []
+        array $context = [],
+        array $config = []
     ): bool;
 }

--- a/src/LaravelHttpClientLoggerServiceProvider.php
+++ b/src/LaravelHttpClientLoggerServiceProvider.php
@@ -32,23 +32,25 @@ class LaravelHttpClientLoggerServiceProvider extends PackageServiceProvider
     {
         PendingRequest::macro('log', function (
             $context = [],
+            $config = [],
             ?HttpLoggerInterface $logger = null,
             ?HttpLoggingFilterInterface $filter = null
         ) {
             return $this->withMiddleware((new LoggingMiddleware(
                 $logger ?? resolve(HttpLoggerInterface::class),
                 $filter ?? resolve(HttpLoggingFilterInterface::class)
-            ))->__invoke($context));
+            ))->__invoke($context, $config));
         });
 
         PendingRequest::macro('logWhen', function (
             $condition,
             $context = [],
+            $config = [],
             ?HttpLoggerInterface $logger = null,
             ?HttpLoggingFilterInterface $filter = null
         ) {
             if ($condition) {
-                return $this->log($context, $logger, $filter);
+                return $this->log($context, $config, $logger, $filter);
             } else {
                 return $this;
             }

--- a/src/Middleware/LoggingMiddleware.php
+++ b/src/Middleware/LoggingMiddleware.php
@@ -26,20 +26,20 @@ class LoggingMiddleware
      * @param array $context
      * @return callable(RequestInterface, array): PromiseInterface
      */
-    public function __invoke($context = []): callable
+    public function __invoke($context = [], $config = []): callable
     {
-        return function (callable $handler) use ($context): callable {
-            return function (RequestInterface $request, array $options) use ($context, $handler): PromiseInterface {
+        return function (callable $handler) use ($context, $config): callable {
+            return function (RequestInterface $request, array $options) use ($context, $config, $handler): PromiseInterface {
                 $start = microtime(true);
 
                 $promise = $handler($request, $options);
 
                 return $promise->then(
-                    function (ResponseInterface $response) use ($context, $request, $start) {
+                    function (ResponseInterface $response) use ($context, $config, $request, $start) {
                         $sec = microtime(true) - $start;
 
-                        if ($this->filter->shouldLog($request, $response, $sec, $context)) {
-                            $this->logger->log($request, $response, $sec, $context);
+                        if ($this->filter->shouldLog($request, $response, $sec, $context, $config)) {
+                            $this->logger->log($request, $response, $sec, $context, $config);
                         }
 
                         return $response;

--- a/tests/HttpLoggerTest.php
+++ b/tests/HttpLoggerTest.php
@@ -119,7 +119,7 @@ class HttpLoggerTest extends TestCase
     {
         Log::swap(new LogFake);
 
-        $this->logger->log($this->request, new Response(200), 0.2, ['test123', 'replace' => ['example.com' => 'mock.org']]);
+        $this->logger->log($this->request, new Response(200), 0.2, ['test123'], ['replace' => ['example.com' => 'mock.org']]);
 
         Log::assertLogged('debug', function ($message, $context) {
             return Str::contains($message, 'mock.org')
@@ -132,7 +132,7 @@ class HttpLoggerTest extends TestCase
     {
         Log::swap(new LogFake);
 
-        $this->logger->log($this->request, new Response(200, [], 'My name is John Doe'), 0.2, ['test123', 'replace' => ['Doe' => 'Smith']]);
+        $this->logger->log($this->request, new Response(200, [], 'My name is John Doe'), 0.2, ['test123'], ['replace' => ['Doe' => 'Smith']]);
 
         Log::assertLogged('debug', function ($message, $context) {
             return Str::contains($message, 'Smith')

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -14,6 +14,11 @@ class MacroTest extends TestCase
         // TODO: Implement
     }
 
+    public function test_log_with_config()
+    {
+        // TODO: Implement
+    }
+
     public function test_log_with_logger()
     {
         // TODO: Implement


### PR DESCRIPTION
This PR adds an extra `$config` parameter to `HttpLoggerInterface`, `HttpLoggingFilterInterface` and the two macros `log` and `logWhen`.

The purpose of this PR is to make it possible to specify configuration on demand.

## Example
The default configuration is to log only request/responses with errors

```
// config/http-client-logger.php
'filtering' => [
    'always' => false,
    '2xx' => false,
    '3xx' => false,
    '4xx' => true,
    '5xx' => true
],
```

with this PR is now possible to log just one request/response to say a specific disk:

```php
$config = [
    'filtering' => [
        'always' => true,
    ],
    'log_to_disk' => [
        'enabled' => true,
        'disk' => 'local',
    ],
];
Http::log([], $config)->get(....);
```