### PR TITLE
Change to current version of the dev dependency timacdonald/log-fake

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5.10",
         "spatie/laravel-ray": "^1.29",
-        "timacdonald/log-fake": "dev-return-types",
+        "timacdonald/log-fake": "^1.9",
         "vimeo/psalm": "^4.20"
     },
     "autoload": {
@@ -44,12 +44,6 @@
             "Bilfeldt\\LaravelHttpClientLogger\\Tests\\": "tests"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/bilfeldt/log-fake.git"
-        }
-    ],
     "scripts": {
         "psalm": "vendor/bin/psalm",
         "test": "vendor/bin/phpunit --colors=always",


### PR DESCRIPTION
Simple change of the dev dependency `timacdonald/log-fake`.

Note that this require the following PR to be merged before: https://github.com/timacdonald/log-fake/pull/33