### PR TITLE
Change PUT to Append for Log Storage

### DIFF
--- a/src/HttpLogger.php
+++ b/src/HttpLogger.php
@@ -84,16 +84,16 @@ class HttpLogger implements HttpLoggerInterface
     protected function logToDisk(string $disk): void
     {
         if (Arr::get($this->config, 'disk_separate_files')) {
-            Storage::disk($disk)->put(
+            Storage::disk($disk)->append(
                 $this->getFileName().'-request'.Str::start($this->fileExt, '.'),
                 $this->psrMessageStringConverter->toString($this->request, $this->getReplace())
             );
-            Storage::disk($disk)->put(
+            Storage::disk($disk)->append(
                 $this->getFileName().'-response'.Str::start($this->fileExt, '.'),
                 $this->psrMessageStringConverter->toString($this->response, $this->getReplace())
             );
         } else {
-            Storage::disk($disk)->put(
+            Storage::disk($disk)->append(
                 $this->getFileName().Str::start($this->fileExt, '.'),
                 $this->getMessage()
             );


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

# Description

Notice that `logToDisk` method replace the storage log file with new response value instead of appending it. This PR is to use `append` method instead of `put`



## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
