### PR TITLE
Added type hint

### DIFF
--- a/src/LaravelHttpClientLoggerServiceProvider.php
+++ b/src/LaravelHttpClientLoggerServiceProvider.php
@@ -35,7 +35,7 @@ class LaravelHttpClientLoggerServiceProvider extends PackageServiceProvider
             $config = [],
             ?HttpLoggerInterface $logger = null,
             ?HttpLoggingFilterInterface $filter = null
-        ) {
+        ): PendingRequest {
             /** @var \Illuminate\Http\Client\PendingRequest $this */
             return $this->withMiddleware((new LoggingMiddleware(
                 $logger ?? app(HttpLoggerInterface::class),
@@ -49,7 +49,7 @@ class LaravelHttpClientLoggerServiceProvider extends PackageServiceProvider
             $config = [],
             ?HttpLoggerInterface $logger = null,
             ?HttpLoggingFilterInterface $filter = null
-        ) {
+        ): PendingRequest {
             if (value($condition)) {
                 /** @var \Illuminate\Http\Client\PendingRequest $this */
                 return $this->log($context, $config, $logger, $filter);
@@ -59,7 +59,7 @@ class LaravelHttpClientLoggerServiceProvider extends PackageServiceProvider
             }
         });
 
-        PendingRequest::macro('logWith', function (HttpLoggerInterface $logger = null) {
+        PendingRequest::macro('logWith', function (HttpLoggerInterface $logger = null): PendingRequest {
             /** @var \Illuminate\Http\Client\PendingRequest $this */
             return $this->withMiddleware((new LoggingMiddleware($logger, new LogAllFilter()))->__invoke());
         });


### PR DESCRIPTION
When using the barryvdh/laravel-ide-helper package, autocomplete will now work.

# Description

Added return type to macro functions. For this type, the package barryvdh/laravel-ide-helper (for generating PHPStorm hints) will add the appropriate hint and PHPStorm will show the completion of the methods.
![img](https://user-images.githubusercontent.com/45426321/213123392-456a7860-6b03-4ebf-8807-21f507e996f2.jpg)



## Does this close any currently open issues?
No


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Any relevant logs, error output, etc?

No

## Any other comments?

No

# Checklist

- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
