### PR TITLE
Adds support for Laravel 10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,15 +9,21 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 7.4]
-        laravel: [9.*, 8.*]
+        php: [8.2, 8.1, 8.0, 7.4]
+        laravel: [10.*, 9.*, 8.*]
         stability: [prefer-stable]
         include:
+          - laravel: 10.*
+            testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
         exclude:
+          - laravel: 10.*
+            php: 7.4
+          - laravel: 10.*
+            php: 8.0
           - laravel: 9.*
             php: 7.4
 

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
-        "illuminate/http": "^8.0 || ^9.0",
-        "illuminate/support": "^8.0 || ^9.0",
+        "illuminate/http": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/support": "^8.0 || ^9.0 || ^10.0",
         "spatie/laravel-package-tools": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
# Description

Adds support for Laravel 10.

## Does this close any currently open issues?
No

## Fixes
Missing support for Laravel 10 in illuminate/http and illuminate/support.

## Type of change
Dependency update.

# Checklist

- [*] I have made corresponding changes to the documentation
- [*] My changes generate no new warnings
- [*] I have added tests that prove my fix is effective or that my feature works
- [*] New and existing unit tests pass locally with my changes
