### PR TITLE
Fix log testing and increase minimum requirement to laravel 9 and php 8.1

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.2'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,17 +9,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 7.4]
-        laravel: [9.*, 8.*]
+        php: [8.2, 8.1]
+        laravel: [10.*, 9.*]
         stability: [prefer-stable]
         include:
+          - laravel: 10.*
+            testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.*
-        exclude:
-          - laravel: 9.*
-            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.1]
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --dev
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `laravel-http-client-logger` will be documented in this f
 
 ## Upgrade guides
 
+### 1.* => 2.
+
+No breaking changes. The only changes are to the development dependencies used for testing and then the minimum Laravel and PHP requirements.
+
 ### 0.3.0 => 1.0.0
 
 This release flattens the configuration variables. It is suggested to republish the configuration after upgrading.
@@ -50,6 +54,13 @@ The following changes are required when updating:
 - Optional: Republish configuration file
 
 ## Changes
+
+### 2.0.0
+
+- Minimum PHP requirement 8.1
+- Add support for PHP 8.2
+- Minimum Laravel requirement 9.0
+- Add support for Laravel 10.*
 
 ### 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 An easy yet very flexible logger for the Laravel HTTP Client.
 
+| Version | Laravel     | PHP            |
+|---------|-------------|----------------|
+| 1.*     | 8.* \| 9.*  | 7.4.* \| 8.0.* |
+| 2.*     | 9.* \| 10.* | 8.1.* \| 8.2.* |
+
 ## Installation
 
 You can install the package via composer:

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,18 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "~8.2.0 | ~8.1.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
-        "illuminate/http": "^8.0 || ^9.0",
-        "illuminate/support": "^8.0 || ^9.0",
+        "illuminate/http": "^9.0 || ^10.0",
+        "illuminate/support": "^9.0 || ^10.0",
         "spatie/laravel-package-tools": "^1.1"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5.10",
         "spatie/laravel-ray": "^1.29",
-        "timacdonald/log-fake": "dev-return-types",
+        "timacdonald/log-fake": "^2.0",
         "vimeo/psalm": "^4.20"
     },
     "autoload": {
@@ -44,12 +44,6 @@
             "Bilfeldt\\LaravelHttpClientLogger\\Tests\\": "tests"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/bilfeldt/log-fake.git"
-        }
-    ],
     "scripts": {
         "psalm": "vendor/bin/psalm",
         "test": "vendor/bin/phpunit --colors=always",

--- a/tests/HttpLoggerTest.php
+++ b/tests/HttpLoggerTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use TiMacDonald\Log\LogEntry;
 use TiMacDonald\Log\LogFake;
 
 class HttpLoggerTest extends TestCase
@@ -26,118 +27,125 @@ class HttpLoggerTest extends TestCase
 
     public function test_response_code_200_logs_debug_level()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(200), 0.2);
 
-        Log::assertLogged('debug');
+        Log::assertLogged(fn (LogEntry $log) => $log->level === 'debug');
     }
 
     public function test_response_code_300_logs_info_level()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(300), 0.2);
 
-        Log::assertLogged('info');
+        Log::assertLogged(fn (LogEntry $log) => $log->level === 'info');
     }
 
     public function test_response_code_400_logs_error_level()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(400), 0.2);
 
-        Log::assertLogged('error');
+        Log::assertLogged(fn (LogEntry $log) => $log->level === 'error');
     }
 
     public function test_response_code_400_logs_critical_level()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(500), 0.2);
 
-        Log::assertLogged('critical');
+        Log::assertLogged(fn (LogEntry $log) => $log->level === 'critical');
     }
 
     public function test_log_contains_request_header()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(200), 0.2);
 
-        Log::assertLogged('debug', function ($message, $context) {
-            return Str::contains($message, 'header1: HIJKL');
+        Log::assertLogged(function (LogEntry $log): bool {
+            return $log->level === 'debug'
+                && Str::contains($log->message, 'header1: HIJKL');
         });
     }
 
     public function test_log_contains_request_body()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(200), 0.2);
 
-        Log::assertLogged('debug', function ($message, $context) {
-            return Str::contains($message, 'TestRequestBody');
+        Log::assertLogged(function (LogEntry $log): bool {
+            return $log->level === 'debug'
+                && Str::contains($log->message, 'TestRequestBody');
         });
     }
 
     public function test_log_contains_response_header()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(200, ['header2' => 'XYZ']), 0.2);
 
-        Log::assertLogged('debug', function ($message, $context) {
-            return Str::contains($message, 'header2: XYZ');
+        Log::assertLogged(function (LogEntry $log): bool {
+            return $log->level === 'debug'
+                && Str::contains($log->message, 'header2: XYZ');
         });
     }
 
     public function test_log_contains_response_body()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(200, [], 'TestResponseBody'), 0.2);
 
-        Log::assertLogged('debug', function ($message, $context) {
-            return Str::contains($message, 'TestResponseBody');
+        Log::assertLogged(function (LogEntry $log): bool {
+            return $log->level === 'debug'
+                && Str::contains($log->message, 'TestResponseBody');
         });
     }
 
     public function test_logs_context()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(200), 0.2, ['context']);
 
-        Log::assertLogged('debug', function ($message, $context) {
-            return $context == ['context'];
+        Log::assertLogged(function (LogEntry $log): bool {
+            return $log->level === 'debug'
+                && $log->context == ['context'];
         });
     }
 
     public function test_replaces_placeholders_from_request()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(200), 0.2, ['test123'], ['replace' => ['example.com' => 'mock.org']]);
 
-        Log::assertLogged('debug', function ($message, $context) {
-            return Str::contains($message, 'mock.org')
-                && !Str::contains($message, 'example.com')
-                && $context == ['test123'];
+        Log::assertLogged(function (LogEntry $log): bool {
+            return $log->level === 'debug'
+                && Str::contains($log->message, 'mock.org')
+                && !Str::contains($log->message, 'example.com')
+                && $log->context == ['test123'];
         });
     }
 
     public function test_replaces_placeholders_from_response()
     {
-        Log::swap(new LogFake());
+        LogFake::bind();
 
         $this->logger->log($this->request, new Response(200, [], 'My name is John Doe'), 0.2, ['test123'], ['replace' => ['Doe' => 'Smith']]);
 
-        Log::assertLogged('debug', function ($message, $context) {
-            return Str::contains($message, 'Smith')
-                && !Str::contains($message, 'Doe')
-                && $context == ['test123'];
+        Log::assertLogged(function (LogEntry $log): bool {
+            return $log->level === 'debug'
+                && Str::contains($log->message, 'Smith')
+                && !Str::contains($log->message, 'Doe')
+                && $log->context == ['test123'];
         });
     }
 }


### PR DESCRIPTION
Superseeds https://github.com/bilfeldt/laravel-http-client-logger/pull/17 by using `timacdonald/log-fake:^2.0`

Increases minimum requirement to Laravel 9 and PHP 8.1|8.2