### PR TITLE
docs: update publish config artisan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $app->withFacades();
 
 Optionally in Laravel publish the config file with:
 ```bash
-php artisan vendor:publish --provider="Bilfeldt\LaravelHttpClientLogger\LaravelHttpClientLoggerServiceProvider" --tag="laravel-http-client-logger-config"
+php artisan vendor:publish --provider="Bilfeldt\LaravelHttpClientLogger\LaravelHttpClientLoggerServiceProvider" --tag="http-client-logger-config"
 ```
 
 ## Usage


### PR DESCRIPTION
# Description

The vendor:publish command was using the wrong tag in the documentation.

## Does this close any currently open issues?

No.


## Type of change

Please delete options that are not relevant.

- [x] Documentation

# Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
