### PR TITLE
Mask sensitive data in logs with the MessageAccessor

### DIFF
--- a/config/http-client-logger.php
+++ b/config/http-client-logger.php
@@ -53,10 +53,14 @@ return [
     |
     | These settings determine what data should be replaced with a placeholder.
     |
-    | - replace_values contains an array of strings that will be replaced anywhere in the request/response
+    | - replace contains an array of strings that will be replaced anywhere in the request/response
+    | - replace_values will be replaced in headers, query parameters and json data (but not json keys)
     | - replace_headers contains an array of header names whose values are replaced with placeholders
     | - replace_query contains an array of query parameter names whose values are replaced with placeholders
+    | - replace_json contains an array of json paths whose values are replaced with placeholders
     */
+    'replace' => [],
+
     'replace_values' => [],
 
     'replace_headers' => [],

--- a/config/http-client-logger.php
+++ b/config/http-client-logger.php
@@ -48,6 +48,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Replace sensitive data with a placeholder before logging
+    |--------------------------------------------------------------------------
+    |
+    | These settings determine what data should be replaced with a placeholder.
+    |
+    | - replace_values contains an array of strings that will be replaced anywhere in the request/response
+    | - replace_headers contains an array of header names whose values are replaced with placeholders
+    | - replace_query contains an array of query parameter names whose values are replaced with placeholders
+    */
+    'replace_values' => [],
+
+    'replace_headers' => [],
+
+    'replace_query' => [],
+
+    'replace_json' => [],
+
+
+    /*
+    |--------------------------------------------------------------------------
     | Logger class
     |--------------------------------------------------------------------------
     |

--- a/src/LaravelHttpClientLoggerServiceProvider.php
+++ b/src/LaravelHttpClientLoggerServiceProvider.php
@@ -79,5 +79,14 @@ class LaravelHttpClientLoggerServiceProvider extends PackageServiceProvider
         $this->app->bind(HttpLoggingFilterInterface::class, function ($app) {
             return $app->make(config('http-client-logger.filter'));
         });
+
+        $this->app->singleton(MessageAccessor::class, function ($app) {
+            return new MessageAccessor(
+                config('http-client-logger.replace_json', []),
+                config('http-client-logger.replace_query', []),
+                config('http-client-logger.replace_headers', []),
+                config('http-client-logger.replace_values', []),
+            );
+        });
     }
 }

--- a/src/MessageAccessor.php
+++ b/src/MessageAccessor.php
@@ -15,20 +15,20 @@ class MessageAccessor
     private array $queryFilters;
     private array $headersFilters;
     private array $jsonFilters;
-    private string $replace;
+    private string $placeholder;
 
     public function __construct(
-        array $jsonFilers = [],
+        array $jsonFilters = [],
         array $queryFilters = [],
         array $headersFilters = [],
         array $values = [],
-        string $replace = '********'
+        string $placeholder = '********'
     ) {
         $this->values = $values;
         $this->queryFilters = $queryFilters;
         $this->headersFilters = $headersFilters;
-        $this->jsonFilters = $jsonFilers;
-        $this->replace = $replace;
+        $this->jsonFilters = $jsonFilters;
+        $this->placeholder = $placeholder;
     }
 
     public function getUri(RequestInterface $request): UriInterface
@@ -37,10 +37,10 @@ class MessageAccessor
         parse_str($uri->getQuery(), $query);
 
         return $uri
-            ->withUserInfo($this->replace($this->values, $this->replace, $uri->getUserInfo()))
-            ->withHost($this->replace($this->values, $this->replace, $uri->getHost()))
-            ->withPath($this->replace($this->values, $this->replace, $uri->getPath()))
-            ->withQuery(Arr::query($this->replaceParameters($query, $this->queryFilters, $this->values, $this->replace)));
+            ->withUserInfo($this->replace($this->values, $this->placeholder, $uri->getUserInfo()))
+            ->withHost($this->replace($this->values, $this->placeholder, $uri->getHost()))
+            ->withPath($this->replace($this->values, $this->placeholder, $uri->getPath()))
+            ->withQuery(Arr::query($this->replaceParameters($query, $this->queryFilters, $this->values, $this->placeholder)));
     }
 
     public function getBase(RequestInterface $request): string
@@ -75,12 +75,12 @@ class MessageAccessor
     {
         foreach ($this->headersFilters as $headersFilter) {
             if ($message->hasHeader($headersFilter)) {
-                $message = $message->withHeader($headersFilter, $this->replace);
+                $message = $message->withHeader($headersFilter, $this->placeholder);
             }
         }
 
         // Header filter applied above as this is an array with two layers
-        return $this->replaceParameters($message->getHeaders(), [], $this->values, $this->replace, false);
+        return $this->replaceParameters($message->getHeaders(), [], $this->values, $this->placeholder, false);
     }
 
     /**
@@ -104,7 +104,7 @@ class MessageAccessor
             json_decode($message->getBody()->__toString(), true),
             $this->jsonFilters,
             $this->values,
-            $this->replace
+            $this->placeholder
         );
     }
 
@@ -115,7 +115,7 @@ class MessageAccessor
         } else {
             $body = $message->getBody()->__toString();
             foreach ($this->values as $value) {
-                $body = str_replace($value, $this->replace, $body);
+                $body = str_replace($value, $this->placeholder, $body);
             }
         }
 

--- a/src/PsrMessageToStringConverter.php
+++ b/src/PsrMessageToStringConverter.php
@@ -18,7 +18,7 @@ class PsrMessageToStringConverter
 
     public function toString(MessageInterface $message, array $replace): string
     {
-        $filteredMessage = $this->messageAccessor->filterMessage($message);
+        $filteredMessage = $message instanceof Request ? $this->messageAccessor->filterRequest($message) : $this->messageAccessor->filterMessage($message);
         return strtr(Message::toString($filteredMessage), $replace);
     }
 

--- a/src/PsrMessageToStringConverter.php
+++ b/src/PsrMessageToStringConverter.php
@@ -9,9 +9,9 @@ use Psr\Http\Message\MessageInterface;
 
 class PsrMessageToStringConverter
 {
-    public function toString(MessageInterface $message, array $placeholders): string
+    public function toString(MessageInterface $message, array $replace): string
     {
-        return strtr(Message::toString($message), $placeholders);
+        return strtr(Message::toString($message), $replace);
     }
 
     public function toRequest(string $message): Request

--- a/src/PsrMessageToStringConverter.php
+++ b/src/PsrMessageToStringConverter.php
@@ -9,9 +9,17 @@ use Psr\Http\Message\MessageInterface;
 
 class PsrMessageToStringConverter
 {
+    protected MessageAccessor $messageAccessor;
+
+    public function __construct(MessageAccessor $messageAccessor)
+    {
+        $this->messageAccessor = $messageAccessor;
+    }
+
     public function toString(MessageInterface $message, array $replace): string
     {
-        return strtr(Message::toString($message), $replace);
+        $filteredMessage = $this->messageAccessor->filterMessage($message);
+        return strtr(Message::toString($filteredMessage), $replace);
     }
 
     public function toRequest(string $message): Request

--- a/tests/HttpLoggerTest.php
+++ b/tests/HttpLoggerTest.php
@@ -3,6 +3,7 @@
 namespace Bilfeldt\LaravelHttpClientLogger\Tests;
 
 use Bilfeldt\LaravelHttpClientLogger\HttpLogger;
+use Bilfeldt\LaravelHttpClientLogger\MessageAccessor;
 use Bilfeldt\LaravelHttpClientLogger\PsrMessageToStringConverter;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -21,7 +22,7 @@ class HttpLoggerTest extends TestCase
     {
         parent::setUp();
 
-        $this->logger = new HttpLogger(new PsrMessageToStringConverter());
+        $this->logger = new HttpLogger(new PsrMessageToStringConverter(new MessageAccessor()));
         $this->request = new Request('GET', 'https://example.com/path?query=ABCDEF', ['header1' => 'HIJKL'], 'TestRequestBody');
     }
 

--- a/tests/PsrMessageToStringConverterTest.php
+++ b/tests/PsrMessageToStringConverterTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Bilfeldt\LaravelHttpClientLogger\Tests;
+
+use Bilfeldt\LaravelHttpClientLogger\MessageAccessor;
+use Bilfeldt\LaravelHttpClientLogger\PsrMessageToStringConverter;
+use GuzzleHttp\Psr7\Message;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class PsrMessageToStringConverterTest extends TestCase
+{
+    public PsrMessageToStringConverter $converter;
+
+    public RequestInterface $request;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $messageAccessor = new MessageAccessor(
+            ['data.baz.*.password'],
+            ['search', 'filter.field2'],
+            ['Authorization'],
+            ['secret'],
+        );
+
+        $this->converter = new PsrMessageToStringConverter($messageAccessor);
+
+        $this->request = new Request(
+            'POST',
+            'https://user:secret@secret.example.com:9000/some-path/secret/should-not-be-removed?test=true&search=foo&filter[field1]=A&filter[field2]=B#anchor',
+            [
+                'Accept'        => 'application/json',
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer 1234567890',
+            ],
+            json_encode([
+                'data' => [
+                    'foo' => 'bar',
+                    'baz' => [
+                        [
+                            'field_1'  => 'value1',
+                            'field_2'  => 'value2',
+                            'password' => '123456',
+                            'secret'   => 'this is not for everyone',
+                            'legacy_replace'   => 'replace array is also still used'
+                        ],
+                    ],
+                ],
+            ])
+        );
+    }
+
+    public function test_to_string_replaces_sensitive_data()
+    {
+        $string = $this->converter->toString($this->request, [ 'legacy_replace' => '********']);
+
+        $this->assertStringContainsString(
+            'POST /some-path/********/should-not-be-removed?test=true&search=%2A%2A%2A%2A%2A%2A%2A%2A',
+            $string,
+            'sensitive data not replaced in URI'
+        );
+
+        $this->assertStringContainsString(
+            'Host: ********.example.com:9000',
+            $string,
+            'sensitive data not replaced in Host header'
+        );
+
+        $this->assertStringContainsString(
+            'Authorization: ********',
+            $string,
+            'sensitive header not masked'
+        );
+
+        $this->assertStringNotContainsString(
+            'legacy_replace',
+            $string,
+            'replace array not used'
+        );
+    }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

# Description

This PR improves the handling of sensitive data, like passwords and auth tokens, by making it possible to easily configure the replacing of sensitive values, headers etc. in the package configuration. It does this by integrating the existing `MessageAccessor` (#13) with the `PsrMessageToStringConverter``

The configuration file template now includes detailed documentation on replacement options available for sensitive data, including:
  - Replace anywhere in the message
  - Replace values
  - Replace headers
  - Replace JSON path

**Backward Compatibility**: By default, this update does not alter the package’s behavior, ensuring compatibility for existing users. However, since logging sensitive data is such [a widespread problem](https://news.ycombinator.com/item?id=41678840), it may be worthwhile to consider in a future release to mask the `Authentication` and `Authorization` headers by default.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update (**documentation change included**)


# Checklist

**currently a draft PR, will review these points before submitting PR**

- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
