### PR TITLE
Update LaravelHttpClientLoggerServiceProvider.php

### DIFF
--- a/src/LaravelHttpClientLoggerServiceProvider.php
+++ b/src/LaravelHttpClientLoggerServiceProvider.php
@@ -59,7 +59,7 @@ class LaravelHttpClientLoggerServiceProvider extends PackageServiceProvider
             }
         });
 
-        PendingRequest::macro('logWith', function (HttpLoggerInterface $logger = null): PendingRequest {
+        PendingRequest::macro('logWith', function (?HttpLoggerInterface $logger = null): PendingRequest {
             /** @var \Illuminate\Http\Client\PendingRequest $this */
             return $this->withMiddleware((new LoggingMiddleware($logger, new LogAllFilter()))->__invoke());
         });


### PR DESCRIPTION
Explicitly mark parameter $logger as nullable

# Description

The parameter has a default value of null, but isn't explicitly  marked as nullable, which causes a warning in PHP 8.4

<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Any relevant logs, error output, etc?

<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
```
[2025-05-08 08:21:38] local.WARNING: {closure:Bilfeldt\LaravelHttpClientLogger\LaravelHttpClientLoggerServiceProvider::packageBooted():62}(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/bilfeldt/laravel-http-client-logger/src/LaravelHttpClientLoggerServiceProvider.php on line 62
```

## Any other comments?

...

# Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
