### PR TITLE
Update LaravelHttpClientLoggerServiceProvider.php

### DIFF
--- a/src/LaravelHttpClientLoggerServiceProvider.php
+++ b/src/LaravelHttpClientLoggerServiceProvider.php
@@ -59,7 +59,7 @@ class LaravelHttpClientLoggerServiceProvider extends PackageServiceProvider
             }
         });
 
-        PendingRequest::macro('logWith', function (?HttpLoggerInterface $logger = null): PendingRequest {
+        PendingRequest::macro('logWith', function (HttpLoggerInterface $logger): PendingRequest {
             /** @var \Illuminate\Http\Client\PendingRequest $this */
             return $this->withMiddleware((new LoggingMiddleware($logger, new LogAllFilter()))->__invoke());
         });


### PR DESCRIPTION
Remove the default `null` parameter for the logWith macro as that would cause a failue since the LoggingMiddleware strictly require a logger.